### PR TITLE
stage 1 deeplinking and pressing notfication opens a warning modal

### DIFF
--- a/temptify/ContentView.swift
+++ b/temptify/ContentView.swift
@@ -1,8 +1,14 @@
 import SwiftUI
 import UserNotifications
 
+class ModalHandler: ObservableObject{
+    static let shared = ModalHandler()
+    @Published var showModal: Bool = false
+}
+
 struct ContentView: View {
     @State private var notificationsSent = UserDefaults.standard.integer(forKey: "notificationsSent")
+    @ObservedObject var modalHandler = ModalHandler.shared
     private let center = UNUserNotificationCenter.current()
     
     var body: some View {
@@ -13,6 +19,7 @@ struct ContentView: View {
             }) {
                 Text("Send Notification")
             }
+            .sheet(isPresented: $modalHandler.showModal, content: {ModalView()})
         }
     }
     
@@ -33,5 +40,34 @@ struct ContentView: View {
                 print("Notification sent successfully")
             }
         }
+    }
+}
+
+struct ModalView: View {
+    @Environment(\.presentationMode) var presentationMode
+    var body: some View {
+        VStack {
+            Text("Are you sure you want to open Instagram?")
+            Button(action: {
+                self.deepLink(app: "Instagram")
+            }) {
+                Text("Take me there")
+            }
+            Button(action: {
+                self.dismissModal()
+            }) {
+                Text("Not now")
+            }
+        }
+    }
+    private func deepLink(app: String) {
+        presentationMode.wrappedValue.dismiss()
+        print("opening app...")
+        let url = URL(string: "maps://")!
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+
+    }
+    private func dismissModal() {
+        presentationMode.wrappedValue.dismiss()
     }
 }

--- a/temptify/temptifyApp.swift
+++ b/temptify/temptifyApp.swift
@@ -19,6 +19,7 @@ struct temptifyApp: App {
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     private let center = UNUserNotificationCenter.current()
+    private let modalHandler = ModalHandler.shared
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         center.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
             if granted {
@@ -31,6 +32,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         return true
     }
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        modalHandler.showModal = true
+        //let contentView = ContentView(modalHandler: modalHandler)
         print("A notification has been clicked")
     }
 }


### PR DESCRIPTION
in this PR we are able to do some preliminary deeplinking to open up another app. If a user clicks on the notification sent by the app, they are brought straight into a modal in the app which prompts them asking if they would like to continue going to the app, or dismiss the temptation.